### PR TITLE
Set defaults to 64-bits and add gcAllowVeryLargeObjects tag

### DIFF
--- a/App.config
+++ b/App.config
@@ -3,4 +3,7 @@
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
+    <runtime>
+      <gcAllowVeryLargeObjects enabled="true" />
+    </runtime>
 </configuration>

--- a/Lokad.FlatFiles.csproj
+++ b/Lokad.FlatFiles.csproj
@@ -30,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
Updated default settings, so that large files can be parsed with no tweak after a clean checkout.